### PR TITLE
🧹 refactor: use idiomatic sqlite result handling in PersistentDict

### DIFF
--- a/src/persistent_dict.py
+++ b/src/persistent_dict.py
@@ -59,6 +59,7 @@ class PersistentDict(MutableMapping[str, Any]):
         # Isolation level is left as default to allow manual transaction
         # control via .commit()
         self.conn = sqlite3.connect(self.filename)
+        self.conn.row_factory = sqlite3.Row
 
         # Write-Ahead Logging (WAL) significantly improves concurrency
         # for key-value loads.
@@ -101,15 +102,14 @@ class PersistentDict(MutableMapping[str, Any]):
             raise RuntimeError("Database connection closed")
 
         query = f"SELECT value FROM {self.tablename} WHERE key = ?"  # nosec
-        cursor = self.conn.execute(query, (key,))
-        row = cursor.fetchone()
+        row = self.conn.execute(query, (key,)).fetchone()
 
         if row is None:
             raise KeyError(key)
 
         try:
             # We strictly use JSON to avoid the security risks of pickle
-            return json.loads(row[0])
+            return json.loads(row["value"])
         except json.JSONDecodeError:
             logger.error(f"Failed to decode JSON for key {key}. Data may be corrupted.")
             raise KeyError(key)
@@ -157,17 +157,14 @@ class PersistentDict(MutableMapping[str, Any]):
             raise RuntimeError("Database connection closed")
 
         query = f"SELECT key FROM {self.tablename}"  # nosec
-        cursor = self.conn.execute(query)
-        for row in cursor:
-            yield row[0]
+        yield from (row["key"] for row in self.conn.execute(query))
 
     def __len__(self) -> int:
         if not self.conn:
             raise RuntimeError("Database connection closed")
 
         query = f"SELECT COUNT(*) FROM {self.tablename}"  # nosec
-        cursor = self.conn.execute(query)
-        result = cursor.fetchone()
+        result = self.conn.execute(query).fetchone()
         return result[0] if result else 0
 
     def close(self) -> None:

--- a/src/persistent_dict.py
+++ b/src/persistent_dict.py
@@ -164,8 +164,7 @@ class PersistentDict(MutableMapping[str, Any]):
             raise RuntimeError("Database connection closed")
 
         query = f"SELECT COUNT(*) FROM {self.tablename}"  # nosec
-        result = self.conn.execute(query).fetchone()
-        return result[0] if result else 0
+        return self.conn.execute(query).fetchone()["COUNT(*)"]
 
     def close(self) -> None:
         """Close the database connection."""


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Refactored `PersistentDict` to use `sqlite3.Row` for its connection `row_factory`.
- Updated `__getitem__`, `__iter__`, and `__len__` to use named column access and more concise patterns.
- Removed redundant manual cursor mapping in `__iter__`.

💡 **Why:** How this improves maintainability
- Enhances code readability by using named columns (e.g., `row["key"]`) instead of numerical indices.
- Simplifies the implementation of dictionary methods, making the code more idiomatic and easier to maintain.
- Reduces boilerplate code associated with manual cursor management.

✅ **Verification:** How you confirmed the change is safe
- Ran the dedicated test suite for `PersistentDict`: `pytest tests/test_persistent_dict.py`. All 8 tests passed.
- Verified that `sqlite3.Row` maintains compatibility with index-based access, ensuring no regressions.

✨ **Result:** The improvement achieved
- A cleaner, more maintainable `PersistentDict` implementation that follows Python best practices for SQLite interaction.

---
*PR created automatically by Jules for task [7134018262499593634](https://jules.google.com/task/7134018262499593634) started by @clayauld*