### PR TITLE
🔒 Fix hardcoded default password in setup wizard

### DIFF
--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -221,6 +221,11 @@ def main() -> None:
                     "\nPassword file was not updated due to errors during the process."
                 )
 
+        finally:
+            # Clean up the temp file if it still exists
+            if os.path.exists(tmp_passwd_file):
+                os.remove(tmp_passwd_file)
+
         # Final check for weak passwords
         weak_passwords = ["pass", "password", "changeme", "your_mqtt_password"]
         current_pass = config.get("mqtt", {}).get("password", "")
@@ -234,8 +239,6 @@ def main() -> None:
         for user in config.get("mqtt_broker", {}).get("users", []):
             if any(w in user.get("password", "").lower() for w in weak_passwords):
                 print(f"\nWARNING: User '{user.get('username')}' has a weak password.")
-
-        finally:
             # Clean up the temp file if it still exists
             if os.path.exists(tmp_passwd_file):
                 os.remove(tmp_passwd_file)

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -2,6 +2,7 @@
 """Setup wizard for Meshtopo Gateway."""
 
 import os
+import secrets
 import shutil
 import subprocess
 from getpass import getpass
@@ -124,7 +125,11 @@ def main() -> None:
         # Default user for integrated broker
         if not config["mqtt_broker"].get("users"):
             config["mqtt_broker"]["users"] = [
-                {"username": "mesh", "password": "changeme", "acl": "readwrite"}
+                {
+                    "username": "mesh",
+                    "password": secrets.token_urlsafe(16),
+                    "acl": "readwrite",
+                }
             ]
 
         username = config["mqtt_broker"]["users"][0]["username"]
@@ -151,6 +156,10 @@ def main() -> None:
 
     mqtt_pass = config.get("mqtt", {}).get("password", "")
     config["mqtt"]["password"] = getpass("MQTT Password: ") or mqtt_pass
+
+    # Synchronize gateway password to internal broker user if using integrated broker
+    if integrated and config.get("mqtt_broker", {}).get("users"):
+        config["mqtt_broker"]["users"][0]["password"] = config["mqtt"]["password"]
 
     # Save configuration
     with open(CONFIG_FILE, "w") as f:
@@ -185,10 +194,13 @@ def main() -> None:
                     print("Skipping user with no username.")
                     continue
 
-                print(f"Setting password for user '{username}'.")
-                password = getpass("Password: ")
+                password = user.get("password")
                 if not password:
-                    print("Password cannot be empty. Skipping user.")
+                    print(f"Setting password for user '{username}'.")
+                    password = getpass("Password: ")
+
+                if not password:
+                    print(f"Password for user '{username}' cannot be empty. Skipping.")
                     continue
 
                 try:
@@ -208,6 +220,20 @@ def main() -> None:
                 print(
                     "\nPassword file was not updated due to errors during the process."
                 )
+
+        # Final check for weak passwords
+        weak_passwords = ["pass", "password", "changeme", "your_mqtt_password"]
+        current_pass = config.get("mqtt", {}).get("password", "")
+        if any(w in current_pass.lower() for w in weak_passwords):
+            print("\n" + "!" * 40)
+            print("WARNING: WEAK PASSWORD DETECTED")
+            print("Your configuration uses a common default password.")
+            print("Please consider changing it to a more secure one.")
+            print("!" * 40)
+
+        for user in config.get("mqtt_broker", {}).get("users", []):
+            if any(w in user.get("password", "").lower() for w in weak_passwords):
+                print(f"\nWARNING: User '{user.get('username')}' has a weak password.")
 
         finally:
             # Clean up the temp file if it still exists


### PR DESCRIPTION
🎯 **What:** Removed a hardcoded default password ("changeme") in the configuration setup wizard.

⚠️ **Risk:** Using hardcoded default passwords can lead to insecure deployments if users do not change them, potentially allowing unauthorized access to the MQTT broker.

🛡️ **Solution:**
- Implemented secure random password generation using the `secrets` module.
- Automated synchronization of MQTT credentials between the gateway and internal broker.
- Added a weak password detection check and warning to alert users of potential security risks.

---
*PR created automatically by Jules for task [10547888053559632791](https://jules.google.com/task/10547888053559632791) started by @clayauld*