### PR TITLE
fix: do not persist temporary mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 <!-- version list -->
 
+## v1.9.0 (2026-05-14)
+
+### Features
+
+- Add node mapping support to tenant configuration and bump version to 1.8.0
+  ([`ddc9c77`](https://github.com/clayauld/meshtopo/commit/ddc9c77a245183b9f715254458cef52dd0c77596))
+
+### Refactoring
+
+- Optimize node counting by pre-calculating length in views and updating template display
+  ([`e9819ee`](https://github.com/clayauld/meshtopo/commit/e9819ee72a90e6cd12b7b7b0938f8329d7989a4d))
+
+
 ## v1.8.0 (2026-05-13)
 
 ### Chores

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "meshtopo"
-version = "1.8.0"
+version = "1.9.0"
 description = "Meshtastic to CalTopo Gateway Service"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gateway_app.py
+++ b/src/gateway_app.py
@@ -601,10 +601,12 @@ class GatewayApp:
             # Fix: Do NOT persist this temporary mapping to avoid
             # "Permanent Callsign" issue. If nodeinfo arrives later,
             # it will be persisted then.
+            # We use the in-memory cache only to avoid redundant logging.
             self.logger.info(
                 f"Allowing unknown device {sanitize_for_log(hardware_id)} "
                 f"(allow_unknown_devices=True). Using hardware_id as callsign."
             )
+            self._callsign_cache[hardware_id] = hardware_id
             return hardware_id
         else:
             self.logger.warning(

--- a/tests/test_gateway_app.py
+++ b/tests/test_gateway_app.py
@@ -308,8 +308,9 @@ class TestGatewayApp:
         # Should return hardware_id
         assert callsign == hardware_id
 
-        # Should NOT be in cache or persistence
-        assert hardware_id not in app._callsign_cache
+        # Should be in cache (to suppress redundant logs) but NOT in persistence
+        assert hardware_id in app._callsign_cache
+        assert app._callsign_cache[hardware_id] == hardware_id
         assert hardware_id not in app.callsign_mapping
 
     def test_telemetry_message(self, app):


### PR DESCRIPTION
Modified GatewayApp._get_or_create_callsign to cache temporary callsign mappings (hardware ID) in memory only when allow_unknown_devices is True. This suppresses redundant logging while avoiding the 'Permanent Callsign' issue where temporary IDs are persisted to the database. Updated corresponding tests.

---
*PR created automatically by Jules for task [966969371160949803](https://jules.google.com/task/966969371160949803) started by @clayauld*