### PR TITLE
fix: robust temporary callsign mapping

### DIFF
--- a/src/gateway_app.py
+++ b/src/gateway_app.py
@@ -78,6 +78,7 @@ class GatewayApp:
         # In-memory caches for performance
         self._node_id_cache: Dict[str, str] = {}
         self._callsign_cache: Dict[str, str] = {}
+        self._temporary_callsigns: set = set()
         self._tenants_cache: Dict[str, Any] = {}
 
         # Track latest status and metrics from devices
@@ -155,6 +156,7 @@ class GatewayApp:
                 self.logger.info("Loading state into memory cache...")
                 self._node_id_cache = dict(self.node_id_mapping)
                 self._callsign_cache = dict(self.callsign_mapping)
+                self._temporary_callsigns.clear()
                 self._tenants_cache = dict(self.tenants_db)
 
             except Exception as e:
@@ -200,6 +202,7 @@ class GatewayApp:
                 # Load into memory cache (empty or after reset)
                 self._node_id_cache = dict(self.node_id_mapping)
                 self._callsign_cache = dict(self.callsign_mapping)
+                self._temporary_callsigns.clear()
 
             # --- Apply Web UI Configuration Overrides ---
             try:
@@ -484,10 +487,17 @@ class GatewayApp:
 
     def _persist_callsign_mapping(self, hardware_id: str, callsign: str) -> None:
         """Persist callsign mapping to cache and database."""
-        if self._callsign_cache.get(hardware_id) == callsign:
+        # Only skip if the callsign matches AND it's not a temporary mapping.
+        # This ensures that if a node was temporarily mapped to its hardware_id,
+        # it can be promoted to a permanent mapping when nodeinfo arrives.
+        if (
+            self._callsign_cache.get(hardware_id) == callsign
+            and hardware_id not in self._temporary_callsigns
+        ):
             return
 
         self._callsign_cache[hardware_id] = callsign
+        self._temporary_callsigns.discard(hardware_id)
         if self.callsign_mapping is not None:
             self.callsign_mapping[hardware_id] = callsign
 
@@ -592,7 +602,17 @@ class GatewayApp:
         # Check cache SECOND (for learned/discovered nodes)
         callsign = self._callsign_cache.get(hardware_id)
         if callsign:
-            return callsign
+            # If it's a temporary mapping, we only return it if policy still allows it
+            if hardware_id in self._temporary_callsigns:
+                if self.config.devices.allow_unknown_devices:
+                    return callsign
+                else:
+                    # Policy changed at runtime, remove from cache/temp
+                    self._callsign_cache.pop(hardware_id, None)
+                    self._temporary_callsigns.discard(hardware_id)
+                    # fall through to block it
+            else:
+                return callsign
 
         # If we reach here, the device is unconfigured (since configured devices
         # are guaranteed to have a device_id and return early).
@@ -601,10 +621,14 @@ class GatewayApp:
             # Fix: Do NOT persist this temporary mapping to avoid
             # "Permanent Callsign" issue. If nodeinfo arrives later,
             # it will be persisted then.
+            # We use the in-memory cache and a temporary set to avoid
+            # redundant logging while allowing elevation to permanent mapping.
             self.logger.info(
                 f"Allowing unknown device {sanitize_for_log(hardware_id)} "
                 f"(allow_unknown_devices=True). Using hardware_id as callsign."
             )
+            self._callsign_cache[hardware_id] = hardware_id
+            self._temporary_callsigns.add(hardware_id)
             return hardware_id
         else:
             self.logger.warning(

--- a/src/gateway_app.py
+++ b/src/gateway_app.py
@@ -78,7 +78,7 @@ class GatewayApp:
         # In-memory caches for performance
         self._node_id_cache: Dict[str, str] = {}
         self._callsign_cache: Dict[str, str] = {}
-        self._temporary_callsigns: set = set()
+        self._temporary_callsigns: set[str] = set()
         self._tenants_cache: Dict[str, Any] = {}
 
         # Track latest status and metrics from devices

--- a/tests/test_gateway_app.py
+++ b/tests/test_gateway_app.py
@@ -308,9 +308,63 @@ class TestGatewayApp:
         # Should return hardware_id
         assert callsign == hardware_id
 
-        # Should NOT be in cache or persistence
-        assert hardware_id not in app._callsign_cache
+        # Should be in cache (to suppress redundant logs) but NOT in persistence
+        assert hardware_id in app._callsign_cache
+        assert app._callsign_cache[hardware_id] == hardware_id
+        assert hardware_id in app._temporary_callsigns
         assert hardware_id not in app.callsign_mapping
+
+    def test_unknown_device_promotion_to_permanent(self, app):
+        """
+        Verify that a temporary callsign mapping is promoted to
+        permanent when nodeinfo arrives.
+        """
+        app.config.devices.allow_unknown_devices = True
+        app.config.get_node_device_id.return_value = None
+        hardware_id = "!promotable"
+
+        # 1. First it's unknown
+        app._get_or_create_callsign(hardware_id)
+        assert hardware_id in app._temporary_callsigns
+        assert hardware_id not in app.callsign_mapping
+
+        # 2. Then nodeinfo arrives with same callsign (hardware_id)
+        msg = {
+            "from": 123,
+            "type": "nodeinfo",
+            "payload": {
+                "id": hardware_id,
+                "longname": hardware_id,  # Same as hardware_id
+            },
+        }
+        app._process_nodeinfo_message(msg, "123")
+
+        # 3. Should now be permanent and removed from temporary set
+        assert hardware_id not in app._temporary_callsigns
+        assert hardware_id in app.callsign_mapping
+        assert app.callsign_mapping[hardware_id] == hardware_id
+
+    def test_unknown_device_blocked_after_policy_change(self, app):
+        """
+        Verify that a previously allowed unknown device is blocked
+        if allow_unknown_devices is changed to False at runtime.
+        """
+        app.config.devices.allow_unknown_devices = True
+        app.config.get_node_device_id.return_value = None
+        hardware_id = "!temp"
+
+        # 1. Allowed first
+        assert app._get_or_create_callsign(hardware_id) == hardware_id
+        assert hardware_id in app._callsign_cache
+        assert hardware_id in app._temporary_callsigns
+
+        # 2. Policy change
+        app.config.devices.allow_unknown_devices = False
+
+        # 3. Should now be blocked and removed from caches
+        assert app._get_or_create_callsign(hardware_id) is None
+        assert hardware_id not in app._callsign_cache
+        assert hardware_id not in app._temporary_callsigns
 
     def test_telemetry_message(self, app):
         msg = {"type": "telemetry", "payload": {"battery_level": 100}}


### PR DESCRIPTION
Enhanced GatewayApp to robustly manage temporary callsign mappings using a dedicated in-memory set. This prevents unintended persistence of hardware IDs as callsigns while allowing for later promotion to permanent storage and correctly respecting runtime policy changes. Added comprehensive tests.

---
*PR created automatically by Jules for task [966969371160949803](https://jules.google.com/task/966969371160949803) started by @clayauld*