### PR TITLE
refactor: improve database closing and remove broad exception catches

### DIFF
--- a/src/gateway_app.py
+++ b/src/gateway_app.py
@@ -163,26 +163,7 @@ class GatewayApp:
                     f"{e}. Resetting state file."
                 )
                 # Close potentially open connections
-                if self.node_id_mapping:
-                    try:
-                        self.node_id_mapping.close()
-                    except Exception:
-                        pass  # nosec
-                if self.callsign_mapping:
-                    try:
-                        self.callsign_mapping.close()
-                    except Exception:
-                        pass  # nosec
-                if self.web_config:
-                    try:
-                        self.web_config.close()
-                    except Exception:
-                        pass  # nosec
-                if self.tenants_db:
-                    try:
-                        self.tenants_db.close()
-                    except Exception:
-                        pass  # nosec
+                self.close()
 
                 # Delete the incompatible file
                 if os.path.exists(db_path):
@@ -387,7 +368,7 @@ class GatewayApp:
             "tenants_db": self.tenants_db,
         }
         for name, db in dbs.items():
-            if db and hasattr(db, "close"):
+            if db is not None and hasattr(db, "close"):
                 try:
                     db.close()
                 except Exception as e:


### PR DESCRIPTION
🎯 **What:** Improved the database closing logic in `GatewayApp` and refactored the initialization failure path.
💡 **Why:** 
- `PersistentDict` evaluates to `False` when empty, which previously caused `close()` to be skipped for empty databases. Using `is not None` fixes this.
- The initialization recovery path had multiple broad exception catches with `nosec` suppressions. Replacing these with a call to the centralized `close()` method improves maintainability and readability.
✅ **Verification:** 
- Created a reproduction script to confirm `PersistentDict` boolean behavior.
- Verified that `self.close()` now correctly handles empty dictionaries.
- Verified that `initialize()` correctly calls `self.close()` during failure recovery using a mocked test script.
✨ **Result:** Cleaner, more robust resource management and improved code health.

---
*PR created automatically by Jules for task [11559288628140490153](https://jules.google.com/task/11559288628140490153) started by @clayauld*